### PR TITLE
Extend VL53L4CX driver

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4CX.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4CX.cpp
@@ -8,14 +8,18 @@
 
 extern const AP_HAL::HAL& hal;
 
-#define REG_MODEL_ID        0x010F
-#define REG_MODULE_TYPE     0x0110
-#define REG_SYSTEM_MODE_START 0x0087
-#define REG_SYSTEM_INTERRUPT_CLEAR 0x0086
-#define REG_RESULT_RANGE_STATUS 0x0089
-#define REG_RESULT_DISTANCE_MM 0x0096
+#define REG_MODEL_ID        VL53LX_IDENTIFICATION__MODEL_ID
+#define REG_MODULE_TYPE     VL53LX_IDENTIFICATION__MODULE_TYPE
+#define REG_SYSTEM_MODE_START VL53LX_SYSTEM__MODE_START
+#define REG_SYSTEM_INTERRUPT_CLEAR VL53LX_SYSTEM__INTERRUPT_CLEAR
+#define REG_RESULT_RANGE_STATUS VL53LX_RESULT__RANGE_STATUS
+#define REG_RESULT_DISTANCE_MM VL53LX_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0
+#define REG_RANGE_CONFIG_VCSEL_PERIOD_A VL53LX_RANGE_CONFIG__VCSEL_PERIOD_A
+#define REG_RANGE_CONFIG_VCSEL_PERIOD_B VL53LX_RANGE_CONFIG__VCSEL_PERIOD_B
+#define REG_OFFSET_MM VL53LX_ALGO__PART_TO_PART_RANGE_OFFSET_MM
 #define EXPECTED_MODEL_ID    0xEB
 #define EXPECTED_MODULE_TYPE 0xAA
+
 
 AP_RangeFinder_VL53L4CX::AP_RangeFinder_VL53L4CX(RangeFinder::RangeFinder_State &_state,
                                                  AP_RangeFinder_Params &_params,
@@ -66,20 +70,71 @@ bool AP_RangeFinder_VL53L4CX::check_id(void)
 
 bool AP_RangeFinder_VL53L4CX::init(DistanceMode mode)
 {
-  // basic mode selection. values based on ST's default presets
-  uint8_t range_setting = 0x03; // long
-  if (mode == DistanceMode::Short) {
-    range_setting = 0x01;
-  } else if (mode == DistanceMode::Medium) {
-    range_setting = 0x02;
-  }
+    // basic mode selection. values based on ST's default presets
+    uint8_t range_setting = 0x03; // long
+    if (mode == DistanceMode::Short) {
+        range_setting = 0x01;
+    } else if (mode == DistanceMode::Medium) {
+        range_setting = 0x02;
+    }
 
-  write_register(0x002D, range_setting); // RANGE_CONFIG__VCSEL_PERIOD_A
+    // stop any previous measurement so we can configure the device
+    write_register(REG_SYSTEM_MODE_START, 0x00);
 
-  start_continuous();
-  dev->register_periodic_callback(
-      50000, FUNCTOR_BIND_MEMBER(&AP_RangeFinder_VL53L4CX::timer, void));
-  return true;
+    // apply range configuration
+    write_register(REG_RANGE_CONFIG_VCSEL_PERIOD_A, range_setting);
+    write_register(REG_RANGE_CONFIG_VCSEL_PERIOD_B, range_setting);
+
+    // basic tuning similar to ST example code
+    write_register(VL53LX_SYSTEM__THRESH_RATE_HIGH, 0x02);
+    write_register16(VL53LX_SYSTEM__STREAM_COUNT_CTRL, 16000);
+    write_register(VL53LX_RESULT_CORE__TOTAL_PERIODS_ELAPSED_SD1, 0x01);
+    write_register(VL53LX_ANA_CONFIG__POWERDOWN_GO1, 0x01);
+    write_register(VL53LX_GPH__SYSTEM__ENABLE_XTALK_PER_QUADRANT, 0x01);
+    write_register16(VL53LX_MCU_TO_HOST_BANK__WR_ACCESS_EN, 50000);
+
+    start_continuous();
+    dev->register_periodic_callback(
+        50000, FUNCTOR_BIND_MEMBER(&AP_RangeFinder_VL53L4CX::timer, void));
+    return true;
+}
+
+bool AP_RangeFinder_VL53L4CX::VL53_Calibrate()
+{
+    // simple averaging based offset calibration
+    uint32_t sum = 0;
+    uint8_t count = 0;
+
+    for (uint8_t i = 0; i < 5; i++) {
+        uint16_t dist = 0;
+        if (get_reading(dist)) {
+            sum += dist;
+            count++;
+        }
+        hal.scheduler->delay(50);
+    }
+
+    if (count == 0) {
+        return false;
+    }
+
+    calibrationData.offset_mm = sum / count;
+    return true;
+}
+
+bool AP_RangeFinder_VL53L4CX::VL53_setCalibration()
+{
+    return write_register16(REG_OFFSET_MM, calibrationData.offset_mm);
+}
+
+bool AP_RangeFinder_VL53L4CX::VL53_getCalibration()
+{
+    uint16_t offset = 0;
+    if (!read_register16(REG_OFFSET_MM, offset)) {
+        return false;
+    }
+    calibrationData.offset_mm = offset;
+    return true;
 }
 
 void AP_RangeFinder_VL53L4CX::start_continuous(void)
@@ -97,7 +152,22 @@ bool AP_RangeFinder_VL53L4CX::get_reading(uint16_t &reading_mm)
     if ((status & 0x1F) == 0) {
         return false;
     }
-    return read_register16(REG_RESULT_DISTANCE_MM, reading_mm);
+
+    if (!read_register16(REG_RESULT_DISTANCE_MM, reading_mm)) {
+        return false;
+    }
+
+    // apply calibration offset
+    if (reading_mm > calibrationData.offset_mm) {
+        reading_mm -= calibrationData.offset_mm;
+    } else {
+        reading_mm = 0;
+    }
+
+    // clear interrupt for next measurement
+    write_register(REG_SYSTEM_INTERRUPT_CLEAR, 0x01);
+
+    return true;
 }
 
 void AP_RangeFinder_VL53L4CX::timer(void)
@@ -132,6 +202,12 @@ bool AP_RangeFinder_VL53L4CX::read_register(uint16_t reg, uint8_t &value)
 {
     uint8_t b[2] = { uint8_t(reg>>8), uint8_t(reg) };
     return dev->transfer(b, 2, &value, 1);
+}
+
+bool AP_RangeFinder_VL53L4CX::write_register16(uint16_t reg, uint16_t value)
+{
+    uint8_t b[4] = { uint8_t(reg >> 8), uint8_t(reg), uint8_t(value >> 8), uint8_t(value) };
+    return dev->transfer(b, 4, nullptr, 0);
 }
 
 bool AP_RangeFinder_VL53L4CX::read_register16(uint16_t reg, uint16_t &value)

--- a/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4CX.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_VL53L4CX.h
@@ -7,6 +7,30 @@
 #include "AP_RangeFinder_Backend.h"
 #include <AP_HAL/I2CDevice.h>
 
+// register addresses taken from ST VL53L4CX driver
+#define VL53LX_IDENTIFICATION__MODEL_ID                      0x010F
+#define VL53LX_IDENTIFICATION__MODULE_TYPE                   0x0110
+#define VL53LX_SYSTEM__MODE_START                            0x0087
+#define VL53LX_SYSTEM__INTERRUPT_CLEAR                       0x0086
+#define VL53LX_RESULT__RANGE_STATUS                          0x0089
+#define VL53LX_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0 0x0096
+#define VL53LX_RANGE_CONFIG__VCSEL_PERIOD_A                  0x0060
+#define VL53LX_RANGE_CONFIG__VCSEL_PERIOD_B                  0x0063
+#define VL53LX_ALGO__PART_TO_PART_RANGE_OFFSET_MM            0x001E
+#define VL53LX_SYSTEM__THRESH_RATE_HIGH                      0x0050
+#define VL53LX_SYSTEM__STREAM_COUNT_CTRL                     0x0084
+#define VL53LX_RESULT_CORE__TOTAL_PERIODS_ELAPSED_SD1        0x00D0
+#define VL53LX_ANA_CONFIG__POWERDOWN_GO1                     0x00E0
+#define VL53LX_GPH__SYSTEM__ENABLE_XTALK_PER_QUADRANT        0x00F0
+#define VL53LX_MCU_TO_HOST_BANK__WR_ACCESS_EN                0x0100
+
+#define EXPECTED_MODEL_ID    0xEB
+#define EXPECTED_MODULE_TYPE 0xAA
+
+struct CalibrationData {
+    uint16_t offset_mm = 0;
+};
+
 class AP_RangeFinder_VL53L4CX : public AP_RangeFinder_Backend
 {
 public:
@@ -30,14 +54,19 @@ private:
     bool init(DistanceMode mode);
     bool check_id(void);
     bool get_reading(uint16_t &reading_mm);
+    bool VL53_Calibrate();
+    bool VL53_setCalibration();
+    bool VL53_getCalibration();
     void start_continuous(void);
     void timer(void);
 
     void write_register(uint16_t reg, uint8_t value);
     bool read_register(uint16_t reg, uint8_t &value);
     bool read_register16(uint16_t reg, uint16_t &value);
+    bool write_register16(uint16_t reg, uint16_t value);
 
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev;
+    CalibrationData calibrationData {};
     uint32_t sum_mm = 0;
     uint16_t counter = 0;
 };


### PR DESCRIPTION
## Summary
- expand VL53L4CX driver initialization to perform more configuration
- clear interrupt after reading measurement
- add calibration API with offset storage
- use named register macros and implement write_register16

## Testing
- `./waf configure --board CubeBlack`
- `./waf copter` *(fails: you need to install empy)*

------
https://chatgpt.com/codex/tasks/task_e_686674fc00508332ac1a9ae0d3f5ab4f